### PR TITLE
Removed find_package command for caches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(OpenDrive REQUIRED)
 find_package(adore_math REQUIRED)
-find_package(caches REQUIRED PATHS ${CMAKE_INSTALL_PREFIX}/../caches/lib/cmake/caches)
 find_package(adore_map REQUIRED)
 
 # -------------------------------------------------------------------


### PR DESCRIPTION
This PR removes just one line from CMakeLists.txt (a find_package command for caches). 

It had been inserted as a workaround for a building issue. This has become obsolete by commit https://github.com/eclipse-adore/adore_map/commit/8d0b31adb5780a6cbf846d409444235c0584dfd3 by @akoerner1 (thanks!)